### PR TITLE
Strip leading/trailing whitespace in input fields

### DIFF
--- a/gpa_calc/helpers.py
+++ b/gpa_calc/helpers.py
@@ -48,7 +48,7 @@ def parse_grades(raw_grades):
     # Convert each course row to a dict
     course_list = []
     for course in courses:
-        course_info = course.split("\t") # Split up fields of row
+        course_info = [field.strip() for field in course.split("\t")] # Split up fields of row
         course_info.append(True) # Assume course affects GPA
         course_fields = ['course', 
                          'title', 


### PR DESCRIPTION
gpacalc was broken for Firefox users because copying the "Grades at a Glance" table on MySwat using Firefox resulted in columns separated by `[space][tab]` while Chrome separates columns using only `[tab]`.

This meant that each field contained an extra trailing space. Since grades like `"A "` (with trailing space) do not match any of the grades in the [`GRADE_POINT_EQUIVS` dictionary](https://github.com/swat-sccs/swarthmore-gpa-calculator/blob/babbcc3722a4c8048de61bf7ac237548e1326b2b/gpa_calc/helpers.py#L8-L21), every course was ignored in GPA calculation, resulting in the `ZeroDivisionError` that generates the "Invalid grade input" error on submission.